### PR TITLE
Merge userProperties instead of overriding it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@arenareturns/launcher",
   "productName": "Arena Returns Launcher",
-  "version": "1.1.0",
+  "version": "1.1.1-SNAPSHOT",
   "description": "Le launcher officiel d'Arena Returns",
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",
+    "debug": "electron-forge start --inspect-electron",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "upload": "electron-forge publish",


### PR DESCRIPTION
Hello,

J'en avais marre que chaque update/repair du client supprime les configs locale du jeu alors je propose ce petit fix consistant à fusionner "intelligemment" le fichier "userPreferences.properties" spécifiquement.

Testé sur windows10, mais pas sur linux malheureusement mes VMs m'ont lâchées :(