### PR TITLE
feat: developer menu items

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",
+    "debug": "electron-forge start --inspect-electron",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "upload": "electron-forge publish",

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -10,3 +10,11 @@ export type Manifest = {
   gameVersion: string;
   carousel: Array<CarouselItem>;
 };
+
+export enum DebugMode {
+  NO_DEBUG,
+  JMX,
+  AGENT,
+  AGENT_SUSPENDED,
+  __LENGTH
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,12 +7,30 @@ import { Updater } from "./updater";
 import { exec } from "child_process";
 import { Utils } from "./utils";
 
+export enum DebugMode {
+  NO_DEBUG,
+  JMX,
+  AGENT,
+  AGENT_SUSPENDED
+}
+
 export namespace IPC {
   let devMode = false;
+  let debugMode: DebugMode = DebugMode.NO_DEBUG;
 
   export function registerEvents(mainWindow: BrowserWindow) {
     ipcMain.on("close", () => {
       app.quit();
+    });
+
+    ipcMain.on("changeDebugMode", (_event, mode:DebugMode) => {
+      debugMode = mode;
+    })
+
+    ipcMain.on("clearLogs", () => {
+      const baseLogDir = path.join(Constants.GAME_PATH, "game");
+      fs.unlinkSync(path.join(baseLogDir, "error.log"));
+      fs.unlinkSync(path.join(baseLogDir, "output.log"));
     });
 
     ipcMain.on("openGameDir", () => {
@@ -50,6 +68,7 @@ export namespace IPC {
     });
 
     ipcMain.on("enableDevMode", (_event) => {
+      mainWindow.webContents.send("devModeEnabled");
       if (!devMode) {
         devMode = true;
         dialog.showMessageBox(mainWindow, {
@@ -127,5 +146,9 @@ export namespace IPC {
 
   export function isDevMode() {
     return devMode;
+  }
+
+  export function getDebugMode() {
+    return debugMode;
   }
 }


### PR DESCRIPTION
Needs [the menu PR](https://github.com/ArenaReturns/Launcher/pull/30) **before** beeing merged.

Adds dev launch option in dev mode (agent/jmx/agent suspended) in the menu
Adds a clear logs button in the menu (dev mode only)

Adds a configuration to debug the electron backend

I'm still new to electron and react so all feedbacks are welcome :)