### PR TITLE
Send debugWrapper arg to wrapper in dev mode

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -75,6 +75,12 @@ export namespace Utils {
 
     // Wrapper entrypoint
     javaArgs.push("com.arenareturns.client.ArenaReturnsWrapper");
+
+    if (IPC.isDevMode()) {
+      //enable debug mode in the wrapper
+      javaArgs.push("debugWrapper");
+    }
+
     return javaArgs.join(" ");
   };
 }


### PR DESCRIPTION
Linked to https://github.com/ArenaReturns/ArenaReturnsWrapper/pull/2 but can be merged first.

If the launcher is in debug mode we add the arg "debugWrapper" to the command line to launch the wrapper.

Tested on win10