### PR TITLE
Bump to 2.1.2 fix: Fix classloading order; the wrapper's ressources must override the core's ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arenareturnslauncher",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arenareturnslauncher",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -1919,13 +1919,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@sec-ant/readable-stream": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.6.0.tgz",
-      "integrity": "sha512-uiBh8DrB5FN35gP6/o8JEhEQ7/ci1jUsOZO/VMUjyvTpjtV54VstOXVj1TvTj/wsT23pfX6butxxh3qufsW3+g==",
-      "extraneous": true,
-      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arenareturnslauncher",
   "description": "Le launcher officiel d'Arena Returns",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "author": {

--- a/packages/main/src/utils.ts
+++ b/packages/main/src/utils.ts
@@ -57,8 +57,8 @@ export const buildJavaArgs = (platform: NodeJS.Platform) => {
   const libPath = path.join(Constants.GAME_PATH, "lib");
   const libFiles = fs.readdirSync(libPath);
   // The dark magic we use to patch bugs requires the wrapper to be loaded after the client.
-  classPath.push("core.jar");
   classPath.push("wrapper.jar");
+  classPath.push("core.jar");
   switch (platform) {
     case "win32":
       libFiles.forEach(file => {


### PR DESCRIPTION
The launcher was loading the core.jar before the wrapper.jar in the classpath so the ressources of the wrapper that are supposed to override the ones in the core.jar were ignored instead